### PR TITLE
Add logger to utils

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ module.exports = {
     ConfigFile: require("./configFile"),
     FSUtils: require("./fs"),
     CryptoUtils: require("./crypto"),
+    Logger: require("./logger"),
     ApiServer: require("./api/server"),
     ApiRequest: require("./api/request"),
     ApiResponse: require("./api/response"),

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,125 @@
+const fs = require("fs");
+
+const colors = {
+  info: "\x1b[32m",
+  debug: "\x1b[35m",
+  trace: "\x1b[36m",
+  warn: "\x1b[33m",
+  error: "\x1b[31m",
+  fatal: "\x1b[1m\x1b[31m",
+  reset: "\x1b[0m"
+}
+
+/**
+ * The `Logger` class is used to keep track of events when debugging IJO.
+ * There are different levels of logs which each have there own function. 
+ * 
+ * ### Log Levels
+ * 
+ * - `info` - Simple information reflecting normal behaviour. Events such as the start and stop of services are included
+ * - `debug` (optional) - More granular information about the events taking place in the running enviroment
+ * - `trace` (optional) - Logs every detail that could be of use. 
+ * - `warn` - Unexpected events/uses that should not occure normally
+ * - `error` - Serious issues that can cause things to fail
+ * - `fatal` - Serious issues that cause the entire application to fail
+ */
+class Logger {
+  /**
+   * Create a new logging instance
+   * @param {string} name Name of the log
+   * @param {string} path Path of file to write log (should be in the ./logs directory)
+   * @param {boolean} debug If the log should accept debug messages
+   * @param {boolean} trace If the log should accept trace messages
+   */
+  constructor(name, path, debug=false, trace=false) {
+    this.name = name;
+    this.path = path;
+    this._debug = debug;
+    this._trace = trace;
+    fs.writeFile(path, "", "utf8", err => {
+      if (err) throw Error(`${this.name} failed to write data to log: ${this.path}`)
+    });
+    this.debug("Created log");
+  }
+
+  /**
+   * Write to the log file
+   * @param {string} msg Message to write to file
+   */
+  async write(msg) {
+    fs.appendFile(this.path, `[${this.timestamp()}] ${msg}\n`, "utf8", err => {
+      if (err) throw Error(`${this.name} failed to write data to log: ${this.path}`)
+    });
+  }
+
+  /**
+   * Get the timestamp
+   */
+  timestamp() {
+    return new Date().toISOString();
+  }
+
+  /**
+   * Log simple information
+   * @param {string} message Message to log
+   */
+  info(message) {
+    message = `${this.name} info: ${message}`;
+    console.log(colors.info + message + colors.reset);
+    this.write(message);
+  }
+
+  /**
+   * Log a debug message
+   * @param {string} message Message to log
+   */
+  debug(message) {
+    if (!this._debug) return;
+    message = `${this.name} debug: ${message}`;
+    console.log(colors.debug + message + colors.reset);
+    this.write(message);
+  }
+
+  /**
+   * Log a trace message
+   * @param {string} message Message to log
+   */
+  trace(message) {
+    if (!this._trace) return;
+    message = `${this.name} trace: ${message}`;
+    console.log(colors.trace + message + colors.reset);
+    this.write(message);
+  }
+
+  /**
+   * Log a warning
+   * @param {string} message Message to log
+   */
+  warn(message) {
+    message = `${this.name} warn: ${message}`;
+    console.log(colors.warn + message + colors.reset);
+    this.write(message);
+  }
+
+  /**
+   * Log an error
+   * @param {string} message Message to log
+   */
+  error(message) {
+    message = `${this.name} error: ${message}`;
+    console.log(colors.error + message + colors.reset);
+    this.write(`${message}`);
+  }
+
+  /**
+   * Log a fatal error
+   * @param {string} message Message to log
+   */
+  fatal(message) {
+    message = `${this.name} fatal: ${message}`;
+    console.log(colors.fatal + message + colors.reset);
+    this.write(`${message}`);
+  }
+}
+
+module.exports = Logger;

--- a/src/logger.js
+++ b/src/logger.js
@@ -73,6 +73,16 @@ class Logger {
   }
 
   /**
+   * A timer that starts when called and returns a function that when invoked, 
+   *   stops the timer and returns the time passed in milliseconds
+   * @returns {function} function to call to stop the timer and get difference in milliseconds
+   */
+  timer() {
+    var timestart = performance.now();
+    return () => {return performance.now() - timestart}
+  }
+
+  /**
    * Log simple information
    * @param {string} message Message to log
    */

--- a/src/logger.js
+++ b/src/logger.js
@@ -48,7 +48,9 @@ class Logger {
    */
   initialize(path) {
     this.path = path;
-    this.info(`Log '${this.name}' initialized at ${path}`);
+    fs.writeFile(path, this.cache, "utf8", err => {
+      if (err) throw Error(`${this.name} failed to write data to log: ${this.path}`)
+    });
   }
 
   /**
@@ -56,8 +58,9 @@ class Logger {
    * @param {string} msg Message to write to file
    */
   async write(msg) {
-    this.cache += `[${this.timestamp()}] ${msg}\n`;
-    fs.writeFile(this.path, this.cache, "utf8", err => {
+    msg = `[${this.timestamp()}] ${msg}\n`;
+    this.cache += msg;
+    fs.appendFile(this.path, msg, "utf8", err => {
       if (err && !this.path) throw Error(`${this.name} failed to write data to log: ${this.path}`) 
     });
   }


### PR DESCRIPTION
This is the logger I've come up with. 

When invoking the logger, you can choose whether or not you include debug and trace messages. 
I think we should use `--debug` and `--trace` tags to control this. 
Also, when `--trace` is enabled, `--debug` should be too (trace is more granular than debug). 

I've also added colour support for the terminal to differentiate the types of messages. 
