### PR TITLE
Require performance from perf_hooks

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const {performance} = require('perf_hooks');
 
 const colors = {
   info: "\x1b[32m",


### PR DESCRIPTION
It seems performance isn't included as global variable in nodejs. Adding is using perf_hooks should work.