### PR TITLE
Force write logs of an initialized logger on close

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -235,7 +235,7 @@ class Logger {
      * @param {String} namespace The namespace.
      */
     trace(message, namespace) {
-        if (this.log_level < 2) return;
+        if (this.logLevel < 2) return;
 
         this.log(message, {level: "trace", namespace});
     }

--- a/src/logger.js
+++ b/src/logger.js
@@ -89,7 +89,7 @@ class Logger {
     async close() {
         if(this.cache.length === 0 || this.writing) return;
         if(this.path) {
-            this.writeCache();
+            this.writeCache(this.path, {force: true});
 
             return;
         }


### PR DESCRIPTION
I like the new cache system, but it seems that an initialized log does not write the remaining logs on close. I've fixed this by forcing the `writeCache`. I may be missing something that means this isn't needed at all 😆 but still working my way through the code. 